### PR TITLE
Adds possibility to link to RSS and iCal-file

### DIFF
--- a/config/middleware.php
+++ b/config/middleware.php
@@ -6,4 +6,5 @@
 $app->add(new \Callingallpapers\Api\Middleware\CORS($app));
 $app->add(new \Callingallpapers\Api\Middleware\OAuth($app));
 $app->add(new \Callingallpapers\Api\Middleware\Renderer($app));
+$app->add(new \Callingallpapers\Api\Middleware\ConvertTypeToAccept());
 $app->add(new Org_Heigl\Middleware\Clacks\Clacks());

--- a/src/Middleware/ConvertTypeToAccept.php
+++ b/src/Middleware/ConvertTypeToAccept.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Copyright (c) 2016-2016 The callingallpapers.com Developer Team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author    Andreas Heigl<andreas@heigl.org>
+ * @copyright 2016-2016 The callingallpapers.com Developer Team
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT-License
+ * @version   0.0
+ * @since     16.01.2016
+ * @link      https://github.com/joindin/callingallpapers
+ */
+
+namespace Callingallpapers\Api\Middleware;
+
+use Callingallpapers\Api\PersistenceLayer\UserPersistenceLayer;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class ConvertTypeToAccept
+{
+    /**
+     * Convert a GET-Param "type" to an Accept-Header
+     *
+     * @param  \Psr\Http\Message\ServerRequestInterface $request  PSR7 request
+     * @param  \Psr\Http\Message\ResponseInterface      $response PSR7 response
+     * @param  callable                                 $next     Next middleware
+     *
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function __invoke(
+        ServerRequestInterface $request,
+        ResponseInterface $response,
+        callable $next
+    ) {
+        $query = $request->getQueryParams();
+        if (! isset($query['type'])) {
+            return $next($request, $response);
+        }
+
+        switch (strtolower($query['type'])) {
+            case 'rss':
+                $request = $request->withHeader('Accept', 'application/rss+xml');
+                break;
+            case 'calendar':
+                $request = $request->withHeader('Accept', 'text/calendar');
+                break;
+            default:
+                break;
+        }
+
+        return $next($request, $response);
+    }
+}

--- a/src/Middleware/ConvertTypeToAccept.php
+++ b/src/Middleware/ConvertTypeToAccept.php
@@ -25,7 +25,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.php MIT-License
  * @version   0.0
  * @since     16.01.2016
- * @link      https://github.com/joindin/callingallpapers
+ * @link      https://github.com/joindin/callingallpapers-api
  */
 
 namespace Callingallpapers\Api\Middleware;

--- a/tests/Middleware/ConvertTypeToAcceptTest.php
+++ b/tests/Middleware/ConvertTypeToAcceptTest.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Copyright (c) 2016-2016} Andreas Heigl<andreas@heigl.org>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author    Andreas Heigl<andreas@heigl.org>
+ * @copyright 2016-2016 Andreas Heigl
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT-License
+ * @version   0.0
+ * @since     01.05.2016
+ * @link      http://github.com/heiglandreas/callingallpapers
+ */
+
+namespace CallingallpapersTest\Api\Middleware;
+
+use Callingallpapers\Api\Middleware\ConvertTypeToAccept;
+
+class ConvertTypeToAcceptTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider responseIsUnchangedWithoutTypeParameterProvider
+     */
+    public function testThatResponseIsUnchangedWithoutTypeParameter($queryString)
+    {
+        // instantiate action
+        $action = new ConvertTypeToAccept();
+
+        // We need a request and response object to invoke the action
+        $environment = \Slim\Http\Environment::mock([
+                'REQUEST_METHOD' => 'GET',
+                'REQUEST_URI' => '/echo',
+                'QUERY_STRING'=>$queryString]
+        );
+        $request = \Slim\Http\Request::createFromEnvironment($environment);
+        $response = new \Slim\Http\Response();
+
+        // run the controller action and test it
+        $newRequest = $action($request, $response, function ($request, $response) {
+            return $request;
+        });
+
+        $this->assertSame($request, $newRequest);
+    }
+
+    public function responseIsUnchangedWithoutTypeParameterProvider()
+    {
+        return [
+            [''],
+            ['foo=bar'],
+            ['type=foo'],
+        ];
+    }
+
+    /**
+     * @dataProvider acceptIsSetWithPropertGetParameterProvider
+     */
+    public function testThatAcceptIsSetWithProperGetParameter($parameter, $acceptHeader)
+    {
+        // instantiate action
+        $action = new ConvertTypeToAccept();
+
+        // We need a request and response object to invoke the action
+        $environment = \Slim\Http\Environment::mock([
+                'REQUEST_METHOD' => 'GET',
+                'REQUEST_URI' => '/echo',
+                'QUERY_STRING'=>'type=' . $parameter]
+        );
+        $request = \Slim\Http\Request::createFromEnvironment($environment);
+        $response = new \Slim\Http\Response();
+
+        // run the controller action and test it
+        $newRequest = $action($request, $response, function ($request, $response) {
+            return $request;
+        });
+
+        $this->assertEquals([$acceptHeader], $newRequest->getHeader('Accept'));
+    }
+
+    public function acceptIsSetWithPropertGetParameterProvider()
+    {
+        return [
+            ['calendar', 'text/calendar'],
+            ['rss', 'application/rss+xml'],
+        ];
+    }
+}

--- a/tests/PersistenceLayer/CfpPersistenceLayerTest.php
+++ b/tests/PersistenceLayer/CfpPersistenceLayerTest.php
@@ -1,14 +1,18 @@
 <?php
+
 /**
- * Copyright (c) 2016-2016} Andreas Heigl<andreas@heigl.org>
+ * Copyright (c) 2016-2016 The callingallpapers.com Developer Team
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -18,11 +22,11 @@
  * THE SOFTWARE.
  *
  * @author    Andreas Heigl<andreas@heigl.org>
- * @copyright 2016-2016 Andreas Heigl
+ * @copyright 2016-2016 The callingallpapers.com Developer Team
  * @license   http://www.opensource.org/licenses/mit-license.php MIT-License
  * @version   0.0
- * @since     18.02.2016
- * @link      http://github.com/heiglandreas/callingallpapers
+ * @since     16.01.2016
+ * @link      https://github.com/joindin/callingallpapers-api
  */
 
 namespace CallingallpapersTest\Api\PersistenceLayer;


### PR DESCRIPTION
This commit allows usage of plain links to iCalendar and RSS-feeds

This is achieved setting a "type"-parameter that will then cause the appropriate Content-Type to be set.