### PR TITLE
Moves coverall-script out of dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,26 +13,22 @@ matrix:
   allow_failures:
   - php: hhvm
   - php: nightly
+
 before_install:
 - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini ||
   return 0; fi
 - composer self-update
-- if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update
-  satooshi/php-coveralls; composer update satooshi/php-coveralls; fi
 
 install:
 - travis_retry composer install --no-interaction --ignore-platform-reqs
+
 script:
-- if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then ./vendor/bin/phpunit -c phpunit.travis.xml
-  --coverage-clover build/logs/clover.xml ; fi
-- if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then ./vendor/bin/phpunit -c phpunit.travis.xml;
-  fi
-- if [[ $EXECUTE_CS_CHECK == 'true' ]]; then ./vendor/bin/php-cs-fixer fix -v --diff
-  --dry-run ; fi
+- composer test
+- if [[ $EXECUTE_CS_CHECK == 'true' ]]; then composer cs-check ; fi
+
 after_script:
 - if [[ $TRAVIS_PULL_REQUEST == "false" && $TRAVIS_BRANCH == "master" && $EXECUTE_TEST_COVERALLS == 'true' ]] ; then
  openssl aes-256-cbc -K $encrypted_944d199e46d0_key -iv $encrypted_944d199e46d0_iv
     -in deploy-key.enc -out deploy-key -d && chmod 600 deploy-key; fi
-- if [[ $TRAVIS_PULL_REQUEST == "false" && $TRAVIS_BRANCH == "master" && $EXECUTE_TEST_COVERALLS == 'true' ]]; then ./vendor/bin/coveralls ; fi
-- if [[ $TRAVIS_PULL_REQUEST == "false" && $TRAVIS_BRANCH == "master" && $EXECUTE_TEST_COVERALLS == 'true' ]] ; then
-  ./vendor/bin/phing deploy; fi
+- if [[ $TRAVIS_PULL_REQUEST == "false" && $TRAVIS_BRANCH == "master" && $EXECUTE_TEST_COVERALLS == 'true' ]]; then  composer sendcoverage ; fi
+- if [[ $TRAVIS_PULL_REQUEST == "false" && $TRAVIS_BRANCH == "master" && $EXECUTE_TEST_COVERALLS == 'true' ]] ; then ./vendor/bin/phing deploy; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,20 @@ matrix:
   include:
   - php: 7.0
     env:
-    - EXECUTE_CS_CHECK=true
-    - EXECUTE_TEST_COVERALLS=true
+      - EXECUTE_CS_CHECK=true
+      - EXECUTE_TEST_COVERALLS=true
+  - php: 7.0
+    env:
+      - DEPS=latest
+  - php: 7.0
+    env:
+      - DEPS=lowest
+  - php: 7.1
+    env:
+      - DEPS=latest
+  - php: 7.1
+    env:
+      - DEPS=lowest
   - php: 7.1
   - php: hhvm
   - php: nightly
@@ -17,6 +29,8 @@ matrix:
 before_install:
 - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini ||
   return 0; fi
+- if [[ $DEPS == 'latest' ]]; then travis_retry composer update ; fi
+- if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable ; fi
 - composer self-update
 
 install:

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "scripts" : {
         "cs-download" : [
-            "if [ ! -e php-cs-fixer ] ; then curl -o php-cs-fixer -L `curl -s https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/releases | grep browser_download_url | head -n 1 | cut -d '\"' -f 4` ; fi",
+            "curl -o php-cs-fixer -L `curl -s https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/releases | grep browser_download_url | head -n 1 | cut -d '\"' -f 4`",
             "chmod 755 php-cs-fixer"
         ],
         "cs-check" : [

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,9 @@
     },
     "scripts" : {
         "cs-download" : [
-            "curl -o php-cs-fixer -L `curl -s https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/releases | grep browser_download_url | head -n 1 | cut -d '\"' -f 4`",
+            "FOO=`curl -s https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/releases | grep browser_download_url | head -n 1 | cut -d '\"' -f 4`",
+            "echo $FOO",
+            "curl -o php-cs-fixer -L $FOO",
             "chmod 755 php-cs-fixer"
         ],
         "cs-check" : [

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "mattketmo/camel": "^1.1",
         "org_heigl/pdo_timezone_helper": "dev-master",
         "theiconic/php-ga-measurement-protocol": "^2.1",
-        "akrabat/rka-ip-address-middleware": "^0.4.0"
+        "akrabat/rka-ip-address-middleware": "^0.5.0"
     },
     "autoload" : {
         "psr-4": {
@@ -26,10 +26,27 @@
         }
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^1.11",
         "mockery/mockery": "^0.9.7",
         "phing/phing": "^2.14",
         "phpunit/dbunit": "^2.0",
         "phpunit/phpunit": "^5.2"
+    },
+    "scripts" : {
+        "cs-download" : [
+            "if [ ! -e php-cs-fixer ] ; then curl -o php-cs-fixer -L `curl -s https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/releases | grep browser_download_url | head -n 1 | cut -d '\"' -f 4`; fi",
+            "chmod 755 php-cs-fixer"
+        ],
+        "cs-check" : [
+            "composer cs-download",
+            "php-cs-fixer fix -v --diff --dry-run"
+        ],
+        "test" : [
+            "./vendor/bin/phpunit -c phpunit.travis.xml --coverage-clover build/logs/clover.xml"
+        ],
+        "sendcoverage" : [
+            "curl -o coveralls -L `curl -s https://api.github.com/repos/satooshi/php-coveralls/releases | grep browser_download_url | head -n 1 | cut -d '\"' -f 4`",
+            "chmod 755 coveralls",
+            ""
+        ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "scripts" : {
         "cs-download" : [
-            "FOO=`curl -s https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/releases | grep browser_download_url | head -n 1 | cut -d '\"' -f 4`",
+            "export FOO=`curl -s https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/releases | grep browser_download_url | head -n 1 | cut -d '\"' -f 4`",
             "echo $FOO",
             "curl -o php-cs-fixer -L $FOO",
             "chmod 755 php-cs-fixer"

--- a/composer.json
+++ b/composer.json
@@ -45,9 +45,9 @@
             "./vendor/bin/phpunit -c phpunit.travis.xml --coverage-clover build/logs/clover.xml"
         ],
         "sendcoverage" : [
-            "curl -o coveralls -L `curl -s https://api.github.com/repos/satooshi/php-coveralls/releases | grep browser_download_url | head -n 1 | cut -d '\"' -f 4`",
+            "curl -o coveralls -L https://github.com/satooshi/php-coveralls/releases/download/v1.0.1/coveralls.phar",
             "chmod 755 coveralls",
-            ""
+            "coveralls"
         ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -3,17 +3,18 @@
     "description" : "The API powering callingallpapers.com",
     "license": "MIT",
     "require": {
-        "slim/slim": "^3.0",
+        "akrabat/rka-ip-address-middleware": "^0.5.0",
         "aporat/slim-json-helpers": "^1.0",
-        "sabre/vobject": "^4.0",
-        "slim/twig-view": "^2.0",
-        "monolog/monolog": "^1.17",
-        "zendframework/zend-feed": "^2.7",
-        "org_heigl/clacks-middleware": "^1.1",
+        "guzzlehttp/guzzle": "^6.2",
         "mattketmo/camel": "^1.1",
+        "monolog/monolog": "^1.17",
+        "org_heigl/clacks-middleware": "^1.1",
         "org_heigl/pdo_timezone_helper": "dev-master",
+        "sabre/vobject": "^4.0",
+        "slim/slim": "^3.0",
+        "slim/twig-view": "^2.0",
         "theiconic/php-ga-measurement-protocol": "^2.1",
-        "akrabat/rka-ip-address-middleware": "^0.5.0"
+        "zendframework/zend-feed": "^2.7"
     },
     "autoload" : {
         "psr-4": {
@@ -33,7 +34,7 @@
     },
     "scripts" : {
         "cs-download" : [
-            "if [ ! -e php-cs-fixer ] ; then curl -o php-cs-fixer -L `curl -s https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/releases | grep browser_download_url | head -n 1 | cut -d '\"' -f 4`; fi",
+            "if [ ! -e php-cs-fixer ] ; then curl -o php-cs-fixer -L `curl -s https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/releases | grep browser_download_url | head -n 1 | cut -d '\"' -f 4` ; fi",
             "chmod 755 php-cs-fixer"
         ],
         "cs-check" : [

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "scripts" : {
         "cs-download" : [
-            "curl -o php-cs-fixer -L `curl -s https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/releases | grep browser_download_url | head -n 1 | cut -d '\"' -f 4`",
+            "curl -o php-cs-fixer -L https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.0.0/php-cs-fixer.phar",
             "chmod 755 php-cs-fixer"
         ],
         "cs-check" : [

--- a/composer.json
+++ b/composer.json
@@ -34,9 +34,7 @@
     },
     "scripts" : {
         "cs-download" : [
-            "export FOO=`curl -s https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/releases | grep browser_download_url | head -n 1 | cut -d '\"' -f 4`",
-            "echo $FOO",
-            "curl -o php-cs-fixer -L $FOO",
+            "curl -o php-cs-fixer -L `curl -s https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/releases | grep browser_download_url | head -n 1 | cut -d '\"' -f 4`",
             "chmod 755 php-cs-fixer"
         ],
         "cs-check" : [

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "2b4de73dc7faf5627347fc2a66e68fb1",
-    "content-hash": "ef687eafea96a80ad54e4eeb02b7b97f",
+    "hash": "6e1962ce12b4f6b772483e178954ba51",
+    "content-hash": "d98459c9b93331a4e231af5115d28039",
     "packages": [
         {
             "name": "akrabat/rka-ip-address-middleware",
-            "version": "0.4",
+            "version": "0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/akrabat/rka-ip-address-middleware.git",
-                "reference": "1c9947fdbaad04614e8b15d55f191f11c39293d1"
+                "reference": "832687b13bae4d7fe889fab1414aef6fafeecf80"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/akrabat/rka-ip-address-middleware/zipball/1c9947fdbaad04614e8b15d55f191f11c39293d1",
-                "reference": "1c9947fdbaad04614e8b15d55f191f11c39293d1",
+                "url": "https://api.github.com/repos/akrabat/rka-ip-address-middleware/zipball/832687b13bae4d7fe889fab1414aef6fafeecf80",
+                "reference": "832687b13bae4d7fe889fab1414aef6fafeecf80",
                 "shasum": ""
             },
             "require": {
@@ -53,7 +53,7 @@
                 "middleware",
                 "psr7"
             ],
-            "time": "2015-11-06 10:38:17"
+            "time": "2016-11-13 12:23:41"
         },
         {
             "name": "aporat/slim-json-helpers",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "6e1962ce12b4f6b772483e178954ba51",
-    "content-hash": "d98459c9b93331a4e231af5115d28039",
+    "hash": "0a1211f255d1be20e3e1cbfc04b14fa3",
+    "content-hash": "e05752d68513c9954430f6bbfa816373",
     "packages": [
         {
             "name": "akrabat/rka-ip-address-middleware",


### PR DESCRIPTION
Instead the PHAR-File is downloaded when needed.