### PR TITLE
Fixes CfP-Start-Date

### DIFF
--- a/src/Entity/Cfp.php
+++ b/src/Entity/Cfp.php
@@ -112,7 +112,7 @@ class Cfp
 
     public function __construct()
     {
-        $this->dateCfpStart   = new \DateTimeImmutable();
+        $this->dateCfpStart   = new \DateTimeImmutable('@0');
         $this->dateCfpEnd     = new \DateTimeImmutable();
         $this->dateEventStart = new \DateTimeImmutable();
         $this->dateEventEnd   = new \DateTimeImmutable();


### PR DESCRIPTION
Currently the start-date will be reset to the current date on every call to the API when no startdate is given.

This commit will stop that behaviour by presetting the CfP-Startdate to timestamp "0".