### PR TITLE
[Closes 23] Trim trailing slash on event URIs

### DIFF
--- a/src/Entity/Cfp.php
+++ b/src/Entity/Cfp.php
@@ -236,7 +236,7 @@ class Cfp
 
     public function setEventUri($eventUri)
     {
-        $this->eventUri = $eventUri;
+        $this->eventUri = rtrim($eventUri, '/');
     }
 
     public function getEventUri()

--- a/tests/Entity/CfpTest.php
+++ b/tests/Entity/CfpTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace CallingallpapersTest\Api\Entity;
+
+use Callingallpapers\Api\Entity\Cfp;
+
+final class CfpTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function setEventUriTrimsTrailingSlash(): void
+    {
+        $uri = 'https://some/uri';
+
+        $cfp = new Cfp();
+        $cfp->setEventUri($uri . '/');
+
+        self::assertEquals($uri, $cfp->getEventUri());
+    }
+}

--- a/tests/Entity/CfpTest.php
+++ b/tests/Entity/CfpTest.php
@@ -9,7 +9,7 @@ final class CfpTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function setEventUriTrimsTrailingSlash(): void
+    public function setEventUriTrimsTrailingSlash()
     {
         $uri = 'https://some/uri';
 


### PR DESCRIPTION
Closes [23](https://github.com/joindin/callingallpapers-api/issues/23)

Events were being duplicated as their URIs are used as unique
identifiers, but the same URI might sometimes have a trailing slash and
sometimes not.

This trims the URI on the entity when setting it.