### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,13 @@ language: php
 php:
 - 7.1
 - 7.2
+- 7.3
 - nightly
 
 matrix:
   fast_finish: true
   allow_failures:
-  - nightly
+  - php: nightly
 
 stages:
 - check
@@ -20,12 +21,12 @@ stages:
 jobs:
   include:
   - stage: check
-    php: 7.2
+    php: 7.3
     script:
     - composer cs-check
   - stage: coverage
     if: branch = master AND type = push
-    php: 7.2
+    php: 7.3
     env: TEST_COVERAGE=true
     before_install:
     - phpenv config-rm xdebug.ini

--- a/tests/PersistenceLayer/CfpPersistenceLayerTest.php
+++ b/tests/PersistenceLayer/CfpPersistenceLayerTest.php
@@ -35,7 +35,6 @@ use Callingallpapers\Api\Entity\Cfp;
 use Callingallpapers\Api\Entity\CfpList;
 use Callingallpapers\Api\PersistenceLayer\CfpPersistenceLayer;
 use Org_Heigl\PdoTimezoneHelper\Handler\PdoTimezoneHandlerInterface;
-use Org_Heigl\PdoTimezoneHelper\PdoTimezoneHelper;
 use PHPUnit\DbUnit\TestCaseTrait;
 use PHPUnit\Framework\TestCase;
 
@@ -109,7 +108,7 @@ CREATE UNIQUE INDEX cfp_hash_uindex ON cfp (hash);
     {
         $cpl = new CfpPersistenceLayer(self::$pdo, $this->timezoneHelper);
 
-        $this->assertInstanceof('Callingallpapers\Api\PersistenceLayer\CfpPersistenceLayer', $cpl);
+        $this->assertInstanceof(CfpPersistenceLayer::class, $cpl);
     }
 
     public function testCreateEntry()
@@ -141,7 +140,7 @@ CREATE UNIQUE INDEX cfp_hash_uindex ON cfp (hash);
         $cpl = new CfpPersistenceLayer(self::$pdo, $this->timezoneHelper);
 
         $content = $cpl->select();
-        $this->assertInstanceof('Callingallpapers\Api\Entity\CfpList', $content);
+        $this->assertInstanceof(CfpList::class, $content);
         $this->assertEquals(2, $content->count());
     }
 
@@ -151,7 +150,7 @@ CREATE UNIQUE INDEX cfp_hash_uindex ON cfp (hash);
         $cpl = new CfpPersistenceLayer(self::$pdo, $this->timezoneHelper);
 
         $content = $cpl->select('ff');
-        $this->assertInstanceof('Callingallpapers\Api\Entity\CfpList', $content);
+        $this->assertInstanceof(CfpList::class, $content);
         $this->assertEquals(1, $content->count());
     }
 
@@ -164,7 +163,7 @@ CREATE UNIQUE INDEX cfp_hash_uindex ON cfp (hash);
         $cpl = new CfpPersistenceLayer(self::$pdo, $this->timezoneHelper);
 
         $content = $cpl->select('fg');
-        $this->assertInstanceof('Callingallpapers\Api\Entity\CfpList', $content);
+        $this->assertInstanceof(CfpList::class, $content);
         $this->assertEquals(0, $content->count());
     }
 


### PR DESCRIPTION
# Changed log
- Add `php-7.3` test on Travis CI build.
- Add the correct setting about letting `php-nightly` test allow to be failure.
- Removing unused defined class namespaces.
- To be consistency, using the `::class` syntax to declare class instances.