### PR TITLE
Fix issue with empty Accept-Header

### DIFF
--- a/src/Middleware/Renderer.php
+++ b/src/Middleware/Renderer.php
@@ -57,6 +57,12 @@ class Renderer
         callable $next
     ) {
         $accept = $request->getHeader('Accept');
+        if ($accept === []) {
+            $jsonHelpers = new JsonHelpers($this->app->getContainer());
+            $jsonHelpers->registerResponseView();
+            $jsonHelpers->registerErrorHandlers();
+            return $next($request, $response);
+        }
 
         if (strpos($accept[0], 'text/calendar') !== false) {
             $container         = $this->app->getContainer();


### PR DESCRIPTION
When no accept header is set the checks are running into a warning as
they exppect there to be at least one Accept header. Thios expectation
has now been fixed. We use the default as soon as no Accept header is
set.