### PR TITLE
New fields in the RSS suggestion

### DIFF
--- a/src/Renderer/RssRenderer.php
+++ b/src/Renderer/RssRenderer.php
@@ -70,13 +70,17 @@ class RssRenderer
                 $entry->setDateModified(new \DateTime($cfp['dateCfpEnd']));
                 $entry->setDateCreated(new \DateTime($cfp['dateCfpEnd']));
                 $entry->setDescription(sprintf(
-                    'CfP for %3$s runs from %1$s to %2$s',
+                    'CfP for %3$s runs from %1$s to %2$s. The event runs from %4$s to %5$s in %6$s',
                     (new \DateTime($cfp['dateCfpStart']))->format('c'),
                     (new \DateTime($cfp['dateCfpEnd']))->format('c'),
-                    $cfp['name']
+                    $cfp['name'],
+                    (new \DateTime($cfp['dateEventStart']))->format('c'),
+                    (new \DateTime($cfp['dateEventEnd']))->format('c'),
+                    $cfp['location']
                 ));
                 $entry->setContent($cfp['description']);
-
+                $entry->setId($cfp['eventUri']);
+                
                 $feed->addEntry($entry);
             } catch (\Exception $e) {
             }


### PR DESCRIPTION
Hi, looking at the API, there is information in the DB that is not present in the RSS feed. Would it be possible to add it?

* ```dateEventStart```
* ```dateEventEnd```
* ```location```

To impact the current logic as little as possible, I'd suggest extending the ```description```:
* from 'CfP for %3$s runs from %1$s to %2$s' 
* to 'CfP for %3$s runs from %1$s to %2$s. The event runs from %4$s to %5$s in %6$s'

Thanks,
Tim

PS: If none of those changes are possible, could we at least add the ```eventUri``` used to compute the SHA-1 hash of the entry? That way I could retrieve the missing data via a GET Request on the REST API. You could use the ```setId``` method of Zend for that. Thanks!